### PR TITLE
Update sessionchooserdialog.cpp

### DIFF
--- a/kdevplatform/shell/sessionchooserdialog.cpp
+++ b/kdevplatform/shell/sessionchooserdialog.cpp
@@ -198,22 +198,23 @@ void SessionChooserDialog::deleteButtonPressed()
 
     QModelIndex index = m_model->index(m_deleteCandidateRow, 0);
     const QString uuid = m_model->data(index, Qt::DisplayRole).toString();
-
+    const Qstring sessionName = m_model->data(1, Qt::DisplayRole).toString();
+    
     TryLockSessionResult result = SessionController::tryLockSession( uuid );
     if( !result.lock ) {
         const QString errCaption = i18nc("@title", "Cannot Delete Session");
         QString errText = i18nc("@info", "<p>Cannot delete a locked session.");
 
         if( result.runInfo.holderPid != -1 ) {
-            errText += i18nc("@info", "<p>The session is locked by %1 on %2 (PID %3).",
-                                result.runInfo.holderApp, result.runInfo.holderHostname, result.runInfo.holderPid);
+            errText += i18nc("@info", "<p>The session %1 is locked by %2 on %3 (PID %4).",
+                                sessionName, result.runInfo.holderApp, result.runInfo.holderHostname, result.runInfo.holderPid);
         }
 
         KMessageBox::error( this, errText, errCaption );
         return;
     }
 
-    const QString text = i18nc("@info", "The session and all contained settings will be deleted. The projects will stay unaffected. Do you really want to continue?");
+    const QString text = i18nc("@info", "The session %1 and all contained settings will be deleted. The projects will stay unaffected. Do you really want to continue?",sessionName);
     const QString caption = i18nc("@title", "Delete Session");
     const KGuiItem deleteItem = KStandardGuiItem::del();
     const KGuiItem cancelItem = KStandardGuiItem::cancel();


### PR DESCRIPTION
Update to display the name of the session in the "Delete Session" confirmation dialogue box before being deleted, as mentioned in this bug (https://bugs.kde.org/show_bug.cgi?id=393138)
Now the "the session is locked by..." message also displays the name of the session selected.